### PR TITLE
v1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ The interface is simplified to a single line of code in the end user's Python sc
 
 SingleDop Installation
 ----------------------
-SingleDop works under Python 2.7 and 3.4 on most Mac/Linux setups. Windows installation and other Python versions are currently untested.
+SingleDop works under Python 2.7-3.8 on most Mac/Linux setups. Windows installation and other Python versions are currently untested.
 
 To install:  
 `python setup.py install`
 
 The following dependencies need to be installed first:
 
-- A robust version of Python 2.7 or 3.4 w/ most standard scientific packages (e.g., numpy, matplotlib, scipy, etc.) - Get one for free here: https://store.continuum.io/cshop/anaconda/
+- A robust version of Python 2.7-3.8 w/ most standard scientific packages (e.g., numpy, matplotlib, scipy, etc.) - Get one for free here: https://store.continuum.io/cshop/anaconda/
 - [The Python Atmospheric Radiation Measurement (ARM) Radar Toolkit (Py-ART)](https://github.com/ARM-DOE/pyart)
 - [Python Turbulence Detection Algorithm (PyTDA)](https://github.com/nasa/PyTDA)
 - [xarray - optional](http://xarray.pydata.org/en/stable/)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='SingleDop',
-    version='1.2',
+    version='1.2.2',
     author='Timothy Lang',
     author_email='timothy.j.lang@nasa.gov',
     packages=['singledop',],

--- a/singledop/singledop.py
+++ b/singledop/singledop.py
@@ -3,8 +3,8 @@ Title/Version
 -------------
 Single Doppler Retrieval Toolkit (SingleDop)
 singledop v1.2
-Developed & tested with Python 2.7 & 3.4
-Last changed 05/22/2016
+Developed & tested with Python 2.7-3.8
+Last changed 10/12/22
 
 
 Author
@@ -37,6 +37,11 @@ using Doppler-radar radial-velocity observations. Q. J. R. Meteorol. Soc., 132,
 
 Change Log
 ----------
+v1.2.2 Changes (10/12/22):
+1. Removed scipy matrix solver and associated exception handling and if
+   statements. The scipy version was causing issues with some systems.
+2. The numpy.linalg.solve is the only matrix solving function now.
+
 v1.2.1 Changes (05/24/18):
 1. Added additional keyword options to four_panel_plot to enable greater
    display flexibility.
@@ -159,7 +164,7 @@ except ImportError:
 
 ##############################
 
-VERSION = '1.1'
+VERSION = '1.2.2'
 
 # Hard coding of constants & default parameters
 DEFAULT_L = 30.0  # km
@@ -490,7 +495,7 @@ class SingleDoppler2D(object):
     def compute_single_doppler_retrieval(self, debug=False):
         """
         Performs single-Doppler retrieval whether input data are real
-        or simulated. Matrix equations solved via stock SciPy/NumPy routines.
+        or simulated. Matrix equations solved via stock NumPy routine.
 
         Parameters
         ----------
@@ -510,12 +515,10 @@ class SingleDoppler2D(object):
         if debug:
             self.A = A
             self.b = b
-        try:
-            # scipy appears to be faster
-            self.z_vector = scipy.linalg.solve(A, b, sym_pos=True)
-        except:
-            print('Singular matrix error, retrying assuming generic matrix')
-            self.z_vector = scipy.linalg.solve(A, b)
+
+        # Solve the matrix equation, this is the main processing hit
+        self.z_vector = np.linalg.solve(A, b)
+
         delta_vr = 0.0 * self.analysis_xf
         delta_vt = 0.0 * self.analysis_xf
         for index in np.arange(len(self.analysis_xf)):

--- a/singledop/singledop.py
+++ b/singledop/singledop.py
@@ -2,7 +2,7 @@
 Title/Version
 -------------
 Single Doppler Retrieval Toolkit (SingleDop)
-singledop v1.2
+singledop v1.2.2
 Developed & tested with Python 2.7-3.8
 Last changed 10/12/22
 


### PR DESCRIPTION
1.2.2 Changes (10/12/22):
1. Removed scipy matrix solver and associated exception handling and if
   statements. The scipy version was causing issues with some systems.
2. The numpy.linalg.solve is the only matrix solving function now.